### PR TITLE
Added global pipelines to Application configuration

### DIFF
--- a/common-pipeline-steps/src/main/scala/com/acxiom/pipeline/steps/HiveSteps.scala
+++ b/common-pipeline-steps/src/main/scala/com/acxiom/pipeline/steps/HiveSteps.scala
@@ -1,0 +1,72 @@
+package com.acxiom.pipeline.steps
+
+import com.acxiom.pipeline.PipelineContext
+import com.acxiom.pipeline.annotations.{StepFunction, StepObject}
+import org.apache.spark.sql.DataFrame
+
+@StepObject
+object HiveSteps {
+
+  @StepFunction("3806f23b-478c-4054-b6c1-37f11db58d38",
+    "Read a DataFrame from Hive",
+    "This step will read a dataFrame in a given format from Hive",
+    "Pipeline")
+  def readDataFrame(hiveStepsOptions: HiveStepsOptions, pipelineContext: PipelineContext): DataFrame ={
+    val spark = pipelineContext.sparkSession.get
+    spark.read
+      .format(hiveStepsOptions.format)
+      .options(hiveStepsOptions.options.getOrElse(Map[String, String]()))
+      .table(hiveStepsOptions.table)
+  }
+
+  @StepFunction("e2b4c011-e71b-46f9-a8be-cf937abc2ec4",
+    "Write DataFrame to Hive",
+    "This step will write a dataFrame in a given format to Hive",
+    "Pipeline")
+  def writeDataFrame(dataFrame: DataFrame, hiveStepsOptions: HiveStepsOptions): Unit = {
+    val writer = dataFrame.write.format(hiveStepsOptions.format)
+      .mode(hiveStepsOptions.saveMode)
+      .options(hiveStepsOptions.options.getOrElse(Map[String, String]()))
+    val w1 = if (hiveStepsOptions.bucketingOptions.isDefined) {
+      val bucketingOptions = hiveStepsOptions.bucketingOptions.get
+      writer.bucketBy(bucketingOptions.numBuckets, bucketingOptions.columns.head, bucketingOptions.columns.drop(1): _*)
+    } else {
+      writer
+    }
+    val w2 = if (hiveStepsOptions.partitionBy.isDefined) {
+      w1.partitionBy(hiveStepsOptions.partitionBy.get: _*)
+    } else {
+      w1
+    }
+    val w3 = if (hiveStepsOptions.sortBy.isDefined) {
+      val sortBy = hiveStepsOptions.sortBy.get
+      w2.sortBy(sortBy.head, sortBy.drop(1): _*)
+    } else {
+      w2
+    }
+    w3.saveAsTable(hiveStepsOptions.table)
+  }
+}
+
+case class HiveStepsOptions(table: String,
+                            format: String = "parquet",
+                            saveMode: String = "Overwrite",
+                            options: Option[Map[String, String]] = None,
+                            bucketingOptions: Option[BucketingOptions] = None,
+                            partitionBy: Option[List[String]] = None,
+                            sortBy: Option[List[String]] = None){
+
+  def addPartitions(cols: List[String]): HiveStepsOptions ={
+    this.copy(partitionBy = Some(partitionBy.getOrElse(List[String]()).filter(c => !cols.contains(c)) ++ cols))
+  }
+
+  def setBucketingOptions(options: BucketingOptions): HiveStepsOptions={
+    this.copy(bucketingOptions=Some(options))
+  }
+
+  def addSortBy(cols: List[String]): HiveStepsOptions={
+    this.copy(sortBy = Some(sortBy.getOrElse(List[String]()).filter(c => !cols.contains(c)) ++ cols))
+  }
+}
+
+case class BucketingOptions(numBuckets: Int, columns: List[String])

--- a/spark-pipeline-engine/docs/application.md
+++ b/spark-pipeline-engine/docs/application.md
@@ -160,6 +160,38 @@ This object allows specifying an initial set of *PipelineParameters*.
 }
 ```
 
+### pipelines
+A list of pipelines definitions that can be referenced in any defined execution.
+
+```json
+{
+  "pipelines": [
+    {
+      "id": "Pipeline1",
+      "name": "Pipeline 1",
+      "steps": [
+        {
+          "id": "Pipeline1Step1",
+          "displayName": "Pipeline1Step1",
+          "type": "preload",
+          "params": [
+            {
+              "type": "text",
+              "name": "value",
+              "required": true,
+              "value": "!mappedObject"
+            }
+          ],
+          "engineMeta": {
+            "spark": "ExecutionSteps.normalFunction"
+          }
+        }
+      ]
+    }
+  ]
+ }
+``` 
+
 ### globals
 The globals object will be merged with the application parameters passed to the 'spark-submit' command. All elements are
 added to the *PipelineContext* globals lookup *as-is* unless it is an object **and** contains the *className* property. 
@@ -199,7 +231,8 @@ to the lookup with the name *mappedObject*.
 The *executions* array is used to define how the application will execute. Each execution contains several settings:
 
 * **id** - This is used to uniquely identify the execution at runtime.
-* **pipelines** - An array containing one or more pipeline definitions to execute.
+* **pipelines** - An array containing one or more pipeline definitions that can override globally defined pipelines.
+* **pipelineIds** - An array of pipeline ids to execute.
 * **parents** - A list of execution *id*s upon which this execution is dependent.
 
 In addition, any of the global *PipelineContext* settings listed above may be defined which will override the global
@@ -210,6 +243,7 @@ definitions.
   "executions": [
     {
       "id": "0",
+      "pipelineIds": ["Pipeline1"],
       "pipelines": [
         {
           "id": "Pipeline1",
@@ -265,6 +299,7 @@ definitions.
     },
     {
       "id": "1",
+      "pipelineIds": ["Pipeline2"],
       "pipelines": [
         {
           "id": "Pipeline2",

--- a/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/applications/Application.scala
+++ b/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/applications/Application.scala
@@ -8,6 +8,7 @@ import com.acxiom.pipeline.{DefaultPipeline, PipelineParameters}
   * @param executions         List of executions that will be used to generate the Execution Plan
   * @param stepPackages       List of packages where step objects are located
   * @param globals            A default set of globals
+  * @param pipelines          A list of pipelines that can be used by the executions
   * @param pipelineListener   The pipeline listener class to use while processing
   * @param securityManager    An alternate security manager class to use while processing
   * @param stepMapper         An alternate pipeline step mapper class to use while processing
@@ -18,6 +19,7 @@ import com.acxiom.pipeline.{DefaultPipeline, PipelineParameters}
 case class Application(executions: Option[List[Execution]],
                        stepPackages: Option[List[String]],
                        globals: Option[Map[String, Any]],
+                       pipelines: Option[List[DefaultPipeline]] = None,
                        pipelineListener: Option[ClassInfo] = None,
                        securityManager: Option[ClassInfo] = None,
                        stepMapper: Option[ClassInfo] = None,
@@ -30,15 +32,18 @@ case class Application(executions: Option[List[Execution]],
   *
   * @param id                 The unique id of this execution to be used by dependent executions
   * @param pipelines          A list of pipelines to execute
+  * @param pipelineIds        A List of pipelineIds, referencing the pipelines defined in the application
   * @param initialPipelineId  The id of the first pipeline that should be executed
   * @param globals            A default set of globals for this execution
+  * @param parents            A list of parent execution ids
   * @param pipelineListener   The pipeline listener class to use while processing this execution
   * @param securityManager    An alternate security manager class to use while processing this execution
   * @param stepMapper         An alternate pipeline step mapper class to use while processing this execution
   * @param pipelineParameters A default set of pipeline parameters to make available while processing this execution
   */
 case class Execution(id: Option[String],
-                     pipelines: Option[List[DefaultPipeline]],
+                     pipelines: Option[List[DefaultPipeline]] = None,
+                     pipelineIds: Option[List[String]] = None,
                      initialPipelineId: Option[String] = None,
                      globals: Option[Map[String, Any]] = None,
                      parents: Option[List[String]] = None,

--- a/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/applications/Application.scala
+++ b/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/applications/Application.scala
@@ -34,6 +34,7 @@ case class Application(executions: Option[List[Execution]],
   * @param pipelines          A list of pipelines to execute
   * @param pipelineIds        A List of pipelineIds, referencing the pipelines defined in the application
   * @param initialPipelineId  The id of the first pipeline that should be executed
+  * @param mergeGlobals       Defines whether to merge or overwrite the application globals with the local globals
   * @param globals            A default set of globals for this execution
   * @param parents            A list of parent execution ids
   * @param pipelineListener   The pipeline listener class to use while processing this execution
@@ -45,6 +46,7 @@ case class Execution(id: Option[String],
                      pipelines: Option[List[DefaultPipeline]] = None,
                      pipelineIds: Option[List[String]] = None,
                      initialPipelineId: Option[String] = None,
+                     mergeGlobals: Boolean = false,
                      globals: Option[Map[String, Any]] = None,
                      parents: Option[List[String]] = None,
                      pipelineListener: Option[ClassInfo] = None,

--- a/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/applications/ApplicationDriverSetup.scala
+++ b/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/applications/ApplicationDriverSetup.scala
@@ -38,10 +38,19 @@ case class ApplicationDriverSetup(parameters: Map[String, Any]) extends DriverSe
     case "applicationJson" => false
     case "applicationConfigPath" => false
     case "applicationConfigurationLoader" => false
+    case "enableHiveSupport" => false
     case _ => true
   }
 
-  private val executions = ApplicationUtils.createExecutionPlan(application, Some(params), sparkConf)
+  // This determines whether the spark session will support hive
+  private val enableHiveSupport: Boolean = parameters.getOrElse("enableHiveSupport", false).asInstanceOf[Boolean]
+
+  private val executions = ApplicationUtils.createExecutionPlan(
+    application = application,
+    globals = Some(params),
+    sparkConf = sparkConf,
+    enableHiveSupport = enableHiveSupport
+  )
 
   /**
     * This function will return the execution plan to be used for the driver.
@@ -71,6 +80,8 @@ case class ApplicationDriverSetup(parameters: Map[String, Any]) extends DriverSe
       ApplicationUtils.refreshPipelineExecution(application, Some(params), execution, plan)
     })
   }
+
+  def isHiveSupportEnabled: Boolean = enableHiveSupport
 
   private def loadApplication(parameters: Map[String, Any]): Application = {
     val json = if (parameters.contains("applicationJson")) {

--- a/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/applications/ApplicationUtils.scala
+++ b/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/applications/ApplicationUtils.scala
@@ -86,9 +86,11 @@ object ApplicationUtils {
     if (execution.pipelines.isEmpty && execution.pipelineIds.isEmpty) {
       throw new IllegalArgumentException("Either pipelines or pipelineIds must be provided for an execution")
     }
+    val executionPipelines = execution.pipelines.getOrElse(List[DefaultPipeline]())
+    val pipelineIds = execution.pipelineIds.getOrElse(List[String]())
     val applicationPipelines = application.pipelines.getOrElse(List[DefaultPipeline]())
-      .filter(p => execution.pipelineIds.get.contains(p.id.get))
-    execution.pipelines.getOrElse(List[DefaultPipeline]()) ++ applicationPipelines
+      .filter(p => !executionPipelines.exists(e => e.id.getOrElse("") == p.id.getOrElse("")) && pipelineIds.contains(p.id.get))
+    executionPipelines ++ applicationPipelines
   }
 
   private def generatePipelineListener(pipelineListenerInfo: Option[ClassInfo],

--- a/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/applications/ApplicationUtils.scala
+++ b/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/applications/ApplicationUtils.scala
@@ -82,7 +82,7 @@ object ApplicationUtils {
     val defaultGlobals = generateGlobals(application.globals, rootGlobals.get, rootGlobals)
     val globalPipelineParameters = generatePipelineParameters(application.pipelineParameters, Some(PipelineParameters()))
     val ctx = pipelineExecution.pipelineContext
-      .copy(globals = generateGlobals(execution.globals, rootGlobals.get, defaultGlobals))
+      .copy(globals = generateGlobals(execution.globals, rootGlobals.get, defaultGlobals, execution.mergeGlobals))
       .copy(parameters = generatePipelineParameters(execution.pipelineParameters, globalPipelineParameters).get)
     pipelineExecution.asInstanceOf[DefaultPipelineExecution].copy(pipelineContext = ctx)
   }

--- a/spark-pipeline-engine/src/test/resources/application-test.json
+++ b/spark-pipeline-engine/src/test/resources/application-test.json
@@ -245,7 +245,7 @@
                 "type": "text",
                 "name": "value",
                 "required": true,
-                "value": "!mappedObject"
+                "value": "!mappedObject2"
               }
             ],
             "engineMeta": {
@@ -255,6 +255,37 @@
         ]
       }],
       "pipelineIds": ["Pipeline1","Pipeline2"],
+      "securityManager": {
+        "className": "com.acxiom.pipeline.applications.TestPipelineSecurityManager",
+        "parameters": {
+          "name": "Sub Security Manager"
+        }
+      },
+      "globals": {
+        "number": 2,
+        "float": 3.5,
+        "string": "sub string",
+        "mappedObject": {
+          "className": "com.acxiom.pipeline.applications.TestGlobalObject",
+          "object": {
+            "name": "Execution Mapped Object",
+            "subObjects": [
+              {
+                "name": "Sub Object 1a"
+              },
+              {
+                "name": "Sub Object 2a"
+              },
+              {
+                "name": "Sub Object 3"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "3",
       "securityManager": {
         "className": "com.acxiom.pipeline.applications.TestPipelineSecurityManager",
         "parameters": {

--- a/spark-pipeline-engine/src/test/resources/application-test.json
+++ b/spark-pipeline-engine/src/test/resources/application-test.json
@@ -46,6 +46,69 @@
       }
     ]
   },
+  "pipelines": [
+    {
+      "id": "Pipeline1",
+      "name": "Pipeline 1",
+      "steps": [
+        {
+          "id": "Pipeline1Step1",
+          "displayName": "Pipeline1Step1",
+          "type": "preload",
+          "params": [
+            {
+              "type": "text",
+              "name": "value",
+              "required": true,
+              "value": "!mappedObject"
+            }
+          ],
+          "engineMeta": {
+            "spark": "ExecutionSteps.normalFunction"
+          }
+        }
+      ]
+    },
+    {
+      "id": "Pipeline2",
+      "name": "Pipeline 2",
+      "steps": [
+        {
+          "id": "Pipeline2Step1",
+          "displayName": "Pipeline2Step1",
+          "type": "preload",
+          "params": [
+            {
+              "type": "text",
+              "name": "value",
+              "required": true,
+              "value": "CHICKEN"
+            },
+            {
+              "type": "object",
+              "name": "parameterObject",
+              "required": true,
+              "className": "com.acxiom.pipeline.applications.TestGlobalObject",
+              "value": {
+                "name": "Parameter Mapped Object",
+                "subObjects": [
+                  {
+                    "name": "Param Object 1"
+                  },
+                  {
+                    "name": "Param Object 2"
+                  }
+                ]
+              }
+            }
+          ],
+          "engineMeta": {
+            "spark": "ExecutionSteps.normalFunction"
+          }
+        }
+      ]
+    }
+  ],
   "globals": {
     "number": 1,
     "float": 1.5,
@@ -68,30 +131,7 @@
   "executions": [
     {
       "id": "0",
-      "pipelines": [
-        {
-          "id": "Pipeline1",
-          "name": "Pipeline 1",
-          "steps": [
-            {
-              "id": "Pipeline1Step1",
-              "displayName": "Pipeline1Step1",
-              "type": "preload",
-              "params": [
-                {
-                  "type": "text",
-                  "name": "value",
-                  "required": true,
-                  "value": "!mappedObject"
-                }
-              ],
-              "engineMeta": {
-                "spark": "ExecutionSteps.normalFunction"
-              }
-            }
-          ]
-        }
-      ],
+      "pipelineIds": ["Pipeline1"],
       "securityManager": {
         "className": "com.acxiom.pipeline.applications.TestPipelineSecurityManager",
         "parameters": {
@@ -188,6 +228,60 @@
             }
           }
         ]
+      }
+    },
+    {
+      "id": "2",
+      "pipelines": [{
+        "id": "Pipeline1",
+        "name": "Pipeline 1",
+        "steps": [
+          {
+            "id": "Pipeline1Step1",
+            "displayName": "Pipeline1Step1",
+            "type": "preload",
+            "params": [
+              {
+                "type": "text",
+                "name": "value",
+                "required": true,
+                "value": "!mappedObject"
+              }
+            ],
+            "engineMeta": {
+              "spark": "ExecutionSteps.normalFunction"
+            }
+          }
+        ]
+      }],
+      "pipelineIds": ["Pipeline2"],
+      "securityManager": {
+        "className": "com.acxiom.pipeline.applications.TestPipelineSecurityManager",
+        "parameters": {
+          "name": "Sub Security Manager"
+        }
+      },
+      "globals": {
+        "number": 2,
+        "float": 3.5,
+        "string": "sub string",
+        "mappedObject": {
+          "className": "com.acxiom.pipeline.applications.TestGlobalObject",
+          "object": {
+            "name": "Execution Mapped Object",
+            "subObjects": [
+              {
+                "name": "Sub Object 1a"
+              },
+              {
+                "name": "Sub Object 2a"
+              },
+              {
+                "name": "Sub Object 3"
+              }
+            ]
+          }
+        }
       }
     }
   ]

--- a/spark-pipeline-engine/src/test/resources/application-test.json
+++ b/spark-pipeline-engine/src/test/resources/application-test.json
@@ -254,7 +254,7 @@
           }
         ]
       }],
-      "pipelineIds": ["Pipeline2"],
+      "pipelineIds": ["Pipeline1","Pipeline2"],
       "securityManager": {
         "className": "com.acxiom.pipeline.applications.TestPipelineSecurityManager",
         "parameters": {

--- a/spark-pipeline-engine/src/test/resources/application-test.json
+++ b/spark-pipeline-engine/src/test/resources/application-test.json
@@ -292,27 +292,10 @@
           "name": "Sub Security Manager"
         }
       },
+      "mergeGlobals": true,
       "globals": {
-        "number": 2,
-        "float": 3.5,
-        "string": "sub string",
-        "mappedObject": {
-          "className": "com.acxiom.pipeline.applications.TestGlobalObject",
-          "object": {
-            "name": "Execution Mapped Object",
-            "subObjects": [
-              {
-                "name": "Sub Object 1a"
-              },
-              {
-                "name": "Sub Object 2a"
-              },
-              {
-                "name": "Sub Object 3"
-              }
-            ]
-          }
-        }
+        "number": 5,
+        "newThing": "Chickens rule!"
       }
     }
   ]

--- a/spark-pipeline-engine/src/test/resources/no-pipeline-application-test.json
+++ b/spark-pipeline-engine/src/test/resources/no-pipeline-application-test.json
@@ -1,0 +1,101 @@
+{
+  "sparkConf": {
+    "kryoClasses": [
+      "org.apache.hadoop.io.LongWritable",
+      "org.apache.http.client.entity.UrlEncodedFormEntity"
+    ],
+    "setOptions": [
+      {
+        "name": "spark.hadoop.io.compression.codecs",
+        "value": "org.apache.hadoop.io.compress.BZip2Codec,org.apache.hadoop.io.compress.DeflateCodec,hadoop.io.compress.Lz4Codec,org.apache.hadoop.io.compress.SnappyCodec,org.apache.hadoop.io.compress.GzipCodec"
+      }
+    ]
+  },
+  "requiredParameters": [
+    "rootLogLevel"
+  ],
+  "stepPackages": [
+    "com.acxiom.pipeline.steps",
+    "com.acxiom.pipeline"
+  ],
+  "pipelineListener": {
+    "className": "com.acxiom.pipeline.applications.TestPipelineListener",
+    "parameters": {
+      "name": "Test Pipeline Listener"
+    }
+  },
+  "securityManager": {
+    "className": "com.acxiom.pipeline.applications.TestPipelineSecurityManager",
+    "parameters": {
+      "name": "Test Security Manager"
+    }
+  },
+  "stepMapper": {
+    "className": "com.acxiom.pipeline.applications.TestPipelineStepMapper",
+    "parameters": {
+      "name": "Test Step Mapper"
+    }
+  },
+  "pipelineParameters": {
+    "parameters":[
+      {
+        "pipelineId": "Pipeline1",
+        "parameters": {
+          "fred": "johnson"
+        }
+      }
+    ]
+  },
+  "globals": {
+    "number": 1,
+    "float": 1.5,
+    "string": "some string",
+    "mappedObject": {
+      "className": "com.acxiom.pipeline.applications.TestGlobalObject",
+      "object": {
+        "name": "Global Mapped Object",
+        "subObjects": [
+          {
+            "name": "Sub Object 1"
+          },
+          {
+            "name": "Sub Object 2"
+          }
+        ]
+      }
+    }
+  },
+  "executions": [
+    {
+      "id": "0",
+      "securityManager": {
+        "className": "com.acxiom.pipeline.applications.TestPipelineSecurityManager",
+        "parameters": {
+          "name": "Sub Security Manager"
+        }
+      },
+      "globals": {
+        "number": 2,
+        "float": 3.5,
+        "string": "sub string",
+        "mappedObject": {
+          "className": "com.acxiom.pipeline.applications.TestGlobalObject",
+          "object": {
+            "name": "Execution Mapped Object",
+            "subObjects": [
+              {
+                "name": "Sub Object 1a"
+              },
+              {
+                "name": "Sub Object 2a"
+              },
+              {
+                "name": "Sub Object 3"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/applications/ApplicationTests.scala
+++ b/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/applications/ApplicationTests.scala
@@ -113,6 +113,18 @@ class ApplicationTests extends FunSpec with BeforeAndAfterAll with Suite {
       setup.pipelineContext.sparkSession.get.stop()
     }
 
+    it("Should respect the 'enableHiveSupport' parameter") {
+      val thrown = intercept[IllegalArgumentException] {
+        val setup = ApplicationDriverSetup(Map[String, Any](
+          "applicationJson" -> applicationJson,
+          "rootLogLevel" -> "OFF",
+          "enableHiveSupport" -> true
+        )
+        )
+      }
+      assert(thrown.getMessage == "Unable to instantiate SparkSession with Hive support because Hive classes are not found.")
+    }
+
     it("Should refresh an application") {
       val setup = ApplicationDriverSetup(Map[String, Any]("applicationJson" -> applicationJson, "rootLogLevel" -> "DEBUG"))
       val executionPlan = setup.executionPlan.get
@@ -180,25 +192,25 @@ class ApplicationTests extends FunSpec with BeforeAndAfterAll with Suite {
       .head.value.get == "CHICKEN")
     // Ensure no parents
     assert(execution4.parents.isEmpty)
-    // Verify the globals object was properly constructed
+    // Verify the globals object was properly merged
     val globals = ctx3.globals.get
-    assert(globals.size == 5)
+    assert(globals.size == 6)
     assert(globals.contains("rootLogLevel"))
     assert(globals.contains("rootLogLevel"))
     assert(globals.contains("number"))
-    assert(globals("number").asInstanceOf[BigInt] == 2)
+    assert(globals("number").asInstanceOf[BigInt] == 5)
     assert(globals.contains("float"))
-    assert(globals("float").asInstanceOf[Double] == 3.5)
+    assert(globals("float").asInstanceOf[Double] == 1.5)
     assert(globals.contains("string"))
-    assert(globals("string").asInstanceOf[String] == "sub string")
+    assert(globals("string").asInstanceOf[String] == "some string")
+    assert(globals("newThing").asInstanceOf[String] == "Chickens rule!")
     assert(globals.contains("mappedObject"))
     val subGlobalObject = globals("mappedObject").asInstanceOf[TestGlobalObject]
-    assert(subGlobalObject.name.getOrElse("") == "Execution Mapped Object")
+    assert(subGlobalObject.name.getOrElse("") == "Global Mapped Object")
     assert(subGlobalObject.subObjects.isDefined)
-    assert(subGlobalObject.subObjects.get.length == 3)
-    assert(subGlobalObject.subObjects.get.head.name.getOrElse("") == "Sub Object 1a")
-    assert(subGlobalObject.subObjects.get(1).name.getOrElse("") == "Sub Object 2a")
-    assert(subGlobalObject.subObjects.get(2).name.getOrElse("") == "Sub Object 3")
+    assert(subGlobalObject.subObjects.get.length == 2)
+    assert(subGlobalObject.subObjects.get.head.name.getOrElse("") == "Sub Object 1")
+    assert(subGlobalObject.subObjects.get(1).name.getOrElse("") == "Sub Object 2")
     // Verify the PipelineParameters object was set properly
     assert(ctx3.parameters.parameters.length == 1)
     assert(ctx3.parameters.parameters.length == 1)

--- a/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/applications/ApplicationTests.scala
+++ b/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/applications/ApplicationTests.scala
@@ -123,7 +123,7 @@ class ApplicationTests extends FunSpec with BeforeAndAfterAll with Suite {
   }
 
   private def verifyApplication(executionPlan: List[PipelineExecution]) = {
-    assert(executionPlan.length == 2)
+    assert(executionPlan.length == 3)
     // First execution
     val execution1 = executionPlan.head
     verifyFirstExecution(execution1)
@@ -131,6 +131,59 @@ class ApplicationTests extends FunSpec with BeforeAndAfterAll with Suite {
     // Second execution
     val execution2 = executionPlan(1)
     verifySecondExecution(execution2)
+
+    // Third Execution
+    val execution3 = executionPlan(2)
+    verifyThirdExecution(execution3)
+  }
+
+  private def verifyThirdExecution(execution3: PipelineExecution) = {
+    val ctx3 = execution3.pipelineContext
+    // Ensure the id is set properly
+    assert(execution3.id == "2")
+    // Use the global listener
+    assert(ctx3.pipelineListener.get.isInstanceOf[TestPipelineListener])
+    assert(ctx3.pipelineListener.get.asInstanceOf[TestPipelineListener].name == "Test Pipeline Listener")
+    // Use a custom security manager
+    assert(ctx3.security.asInstanceOf[TestPipelineSecurityManager].name == "Sub Security Manager")
+    // Use the global pipeline parameters
+    assert(ctx3.parameters.parameters.length == 1)
+    assert(ctx3.parameters.parameters.head.parameters.getOrElse("fred", "") == "johnson")
+    // Use the global step mapper
+    assert(ctx3.parameterMapper.asInstanceOf[TestPipelineStepMapper].name == "Test Step Mapper")
+    // Validate the correct pipelines are set
+    assert(execution3.pipelines.length == 2)
+    // Validate the correct "Pipeline2" was selected by checking for the "CHICKEN" value in the "value" param
+    assert(execution3.pipelines.filter(p => p.id.get == "Pipeline2")
+      .head.steps.get.head.params.get.filter(pa => pa.name.get == "value")
+      .head.value.get == "CHICKEN")
+    // Ensure no parents
+    assert(execution3.parents.isEmpty)
+    // Verify the globals object was properly constructed
+    val globals = ctx3.globals.get
+    assert(globals.size == 5)
+    assert(globals.contains("rootLogLevel"))
+    assert(globals.contains("rootLogLevel"))
+    assert(globals.contains("number"))
+    assert(globals("number").asInstanceOf[BigInt] == 2)
+    assert(globals.contains("float"))
+    assert(globals("float").asInstanceOf[Double] == 3.5)
+    assert(globals.contains("string"))
+    assert(globals("string").asInstanceOf[String] == "sub string")
+    assert(globals.contains("mappedObject"))
+    val subGlobalObject = globals("mappedObject").asInstanceOf[TestGlobalObject]
+    assert(subGlobalObject.name.getOrElse("") == "Execution Mapped Object")
+    assert(subGlobalObject.subObjects.isDefined)
+    assert(subGlobalObject.subObjects.get.length == 3)
+    assert(subGlobalObject.subObjects.get.head.name.getOrElse("") == "Sub Object 1a")
+    assert(subGlobalObject.subObjects.get(1).name.getOrElse("") == "Sub Object 2a")
+    assert(subGlobalObject.subObjects.get(2).name.getOrElse("") == "Sub Object 3")
+    // Verify the PipelineParameters object was set properly
+    assert(ctx3.parameters.parameters.length == 1)
+    assert(ctx3.parameters.parameters.length == 1)
+    assert(ctx3.parameters.hasPipelineParameters("Pipeline1"))
+    assert(ctx3.parameters.getParametersByPipelineId("Pipeline1").get.parameters.size == 1)
+    assert(ctx3.parameters.getParametersByPipelineId("Pipeline1").get.parameters("fred").asInstanceOf[String] == "johnson")
   }
 
   private def verifySecondExecution(execution2: PipelineExecution) = {


### PR DESCRIPTION
Pipelines can now be defined globally in the application json, then reference by Id in the executions.
Pipelines can still be defined in the execution, and global pipelines can be overridden.