### PR TITLE
Fixed execution with empty parents not being part of root executions

### DIFF
--- a/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/PipelineDependencyExecutor.scala
+++ b/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/PipelineDependencyExecutor.scala
@@ -18,7 +18,7 @@ object PipelineDependencyExecutor {
     */
   def executePlan(executions: List[PipelineExecution]): Unit = {
     // Find the initial executions
-    val rootExecutions = executions.filter(_.parents.isEmpty)
+    val rootExecutions = executions.filter(e => e.parents.isEmpty || e.parents.get.isEmpty)
     // Only execute if there is at least one execution
     if (rootExecutions.nonEmpty) {
       // Create an execution lookup

--- a/spark-pipeline-engine/src/test/resources/single-execution.json
+++ b/spark-pipeline-engine/src/test/resources/single-execution.json
@@ -6,6 +6,7 @@
   "executions": [
     {
       "id": "0",
+      "parents": [],
       "pipelines": [
         {
           "id": "Pipeline1",

--- a/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/ListenerValidations.scala
+++ b/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/ListenerValidations.scala
@@ -10,7 +10,10 @@ class ListenerValidations {
     results += result
   }
 
-  def validate(): Unit = {
+  def validate(expectedValidations: Int = -1): Unit = {
+    if (expectedValidations > -1) {
+      assert(expectedValidations == results.length, "Expected validations count does not match")
+    }
     results.foreach(result => assert(result._2, result._1))
   }
 }

--- a/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/PipelineDependencyExecutorTests.scala
+++ b/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/PipelineDependencyExecutorTests.scala
@@ -107,7 +107,7 @@ class PipelineDependencyExecutorTests extends FunSpec with BeforeAndAfterAll wit
       }
       val application = ApplicationUtils.parseApplication(Source.fromInputStream(getClass.getResourceAsStream("/single-execution.json")).mkString)
       PipelineDependencyExecutor.executePlan(ApplicationUtils.createExecutionPlan(application, None, SparkTestHelper.sparkConf, listener))
-      results.validate()
+      results.validate(1)
     }
 
     it("Should execute a simple dependency graph of two pipeline chains") {


### PR DESCRIPTION
Fixed an issue where having an empty parents array on an execution caused it to be ignored as a root execution