### PR TITLE
Adding parameter type checking to ReflectionUtils

### DIFF
--- a/application-utils/pom.xml
+++ b/application-utils/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.acxiom</groupId>
         <artifactId>spark-pipeline-driver</artifactId>
-        <version>1.3.3-SNAPSHOT</version>
+        <version>1.3.4-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/common-pipeline-steps/pom.xml
+++ b/common-pipeline-steps/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.acxiom</groupId>
         <artifactId>spark-pipeline-driver</artifactId>
-        <version>1.3.3-SNAPSHOT</version>
+        <version>1.3.4-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pipeline-drivers-examples/pom.xml
+++ b/pipeline-drivers-examples/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.acxiom</groupId>
         <artifactId>spark-pipeline-driver</artifactId>
-        <version>1.3.3-SNAPSHOT</version>
+        <version>1.3.4-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.acxiom</groupId>
     <artifactId>spark-pipeline-driver</artifactId>
-    <version>1.3.3-SNAPSHOT</version>
+    <version>1.3.4-SNAPSHOT</version>
     <name>${project.artifactId}</name>
     <packaging>pom</packaging>
     <description>Spark Pipeline Driver Engine</description>

--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
         <encoding>UTF-8</encoding>
         <scala.version>2.11.12</scala.version>
         <scala.compat.version>2.11</scala.compat.version>
-        <spark.compat.version>2.4</spark.compat.version>
-        <spark.version>2.4.2</spark.version>
-        <json4s.version>3.5.3</json4s.version>
+        <spark.compat.version>2.3</spark.compat.version>
+        <spark.version>2.3.3</spark.version>
+        <json4s.version>3.2.11</json4s.version>
         <scala.style.config>${basedir}/scalastyle_config.xml</scala.style.config>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.core.codeCoveragePlugin>scoverage</sonar.core.codeCoveragePlugin>

--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
         <encoding>UTF-8</encoding>
         <scala.version>2.11.12</scala.version>
         <scala.compat.version>2.11</scala.compat.version>
-        <spark.compat.version>2.3</spark.compat.version>
-        <spark.version>2.3.3</spark.version>
-        <json4s.version>3.2.11</json4s.version>
+        <spark.compat.version>2.4</spark.compat.version>
+        <spark.version>2.4.2</spark.version>
+        <json4s.version>3.5.3</json4s.version>
         <scala.style.config>${basedir}/scalastyle_config.xml</scala.style.config>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.core.codeCoveragePlugin>scoverage</sonar.core.codeCoveragePlugin>

--- a/spark-pipeline-engine/pom.xml
+++ b/spark-pipeline-engine/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.acxiom</groupId>
         <artifactId>spark-pipeline-driver</artifactId>
-        <version>1.3.3-SNAPSHOT</version>
+        <version>1.3.4-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/PipelineExecutor.scala
+++ b/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/PipelineExecutor.scala
@@ -93,7 +93,7 @@ object PipelineExecutor {
       // process step normally if empty
       case "" if step.`type`.getOrElse("") == "fork" => processForkStep(step, pipeline, steps, parameterValues, pipelineContext)
       case "" if step.`type`.getOrElse("") == "step-group" => processStepGroup(step, pipeline, steps, parameterValues, pipelineContext)
-      case "" => ReflectionUtils.processStep(step, parameterValues, ssContext)
+      case "" => ReflectionUtils.processStep(step, pipeline, parameterValues, ssContext)
       case value: String =>
         logger.debug(s"Evaluating execute if empty: $value")
         // wrap the value in a parameter object
@@ -102,7 +102,7 @@ object PipelineExecutor {
         ret match {
           case option: Option[Any] => if (option.isEmpty) {
             logger.debug("Executing step normally")
-            ReflectionUtils.processStep(step, parameterValues, ssContext)
+            ReflectionUtils.processStep(step, pipeline, parameterValues, ssContext)
           } else {
             logger.debug("Returning existing value")
             PipelineStepResponse(option, None)

--- a/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/utils/ReflectionUtils.scala
+++ b/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/utils/ReflectionUtils.scala
@@ -2,11 +2,10 @@ package com.acxiom.pipeline.utils
 
 import java.lang.reflect.InvocationTargetException
 
-import com.acxiom.pipeline.{PipelineContext, PipelineException, PipelineStep, PipelineStepResponse}
+import com.acxiom.pipeline.{PipelineContext, PipelineStep, PipelineStepResponse}
 import org.apache.log4j.Logger
 
 import scala.annotation.tailrec
-import scala.collection.immutable.Map.Map1
 import scala.reflect.runtime.universe._
 import scala.reflect.runtime.{universe => ru}
 import scala.runtime.BoxedUnit

--- a/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/utils/ReflectionUtils.scala
+++ b/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/utils/ReflectionUtils.scala
@@ -224,36 +224,30 @@ object ReflectionUtils {
   }
 
   private def validateParamTypeAssignment(runtimeMirror: Mirror,
-                           param: Symbol,
-                           isOption: Boolean,
-                           finalValue: Any,
-                           finalValueType: String,
-                           funcName: String): Unit = {
-    if (isOption && finalValue.asInstanceOf[Option[_]].isEmpty) {
-      return
-    }
-    val paramClass = runtimeMirror.runtimeClass(if (isOption) param.typeSignature.typeArgs.head else param.typeSignature)
-    val isAssignable = finalValue match {
-      case b: java.lang.Boolean => paramClass.isAssignableFrom(b.asInstanceOf[Boolean].getClass)
-      case i: java.lang.Integer => paramClass.isAssignableFrom(i.asInstanceOf[Int].getClass)
-      case l: java.lang.Long => paramClass.isAssignableFrom(l.asInstanceOf[Long].getClass)
-      case s: java.lang.Short => paramClass.isAssignableFrom(s.asInstanceOf[Short].getClass)
-      case c: java.lang.Character => paramClass.isAssignableFrom(c.asInstanceOf[Char].getClass)
-      case d: java.lang.Double => paramClass.isAssignableFrom(d.asInstanceOf[Double].getClass)
-      case f: java.lang.Float => paramClass.isAssignableFrom(f.asInstanceOf[Float].getClass)
-      case by: java.lang.Byte => paramClass.isAssignableFrom(by.asInstanceOf[Byte].getClass)
-      case _ =>
-        if (isOption) {
-          paramClass.isAssignableFrom(finalValue.asInstanceOf[Option[_]].get.getClass)
-        }
-        else {
-          paramClass.isAssignableFrom(finalValue.getClass)
-        }
-    }
-    if (!isAssignable) {
-      val message = s"Failed to map value [$finalValue] of type [$finalValueType] to paramName [${param.name.toString}] of" +
-        s" type [${param.typeSignature}] for method [$funcName]"
-      throw new IllegalArgumentException(message)
+                                          param: Symbol,
+                                          isOption: Boolean,
+                                          value: Any,
+                                          valueType: String,
+                                          funcName: String): Unit = {
+    if (!(isOption && value.asInstanceOf[Option[_]].isEmpty)) {
+      val finalValue = if (isOption) value.asInstanceOf[Option[_]].get else value
+      val paramClass = runtimeMirror.runtimeClass(if (isOption) param.typeSignature.typeArgs.head else param.typeSignature)
+      val isAssignable = finalValue match {
+        case b: java.lang.Boolean => paramClass.isAssignableFrom(b.asInstanceOf[Boolean].getClass)
+        case i: java.lang.Integer => paramClass.isAssignableFrom(i.asInstanceOf[Int].getClass)
+        case l: java.lang.Long => paramClass.isAssignableFrom(l.asInstanceOf[Long].getClass)
+        case s: java.lang.Short => paramClass.isAssignableFrom(s.asInstanceOf[Short].getClass)
+        case c: java.lang.Character => paramClass.isAssignableFrom(c.asInstanceOf[Char].getClass)
+        case d: java.lang.Double => paramClass.isAssignableFrom(d.asInstanceOf[Double].getClass)
+        case f: java.lang.Float => paramClass.isAssignableFrom(f.asInstanceOf[Float].getClass)
+        case by: java.lang.Byte => paramClass.isAssignableFrom(by.asInstanceOf[Byte].getClass)
+        case _ => paramClass.isAssignableFrom(finalValue.getClass)
+      }
+      if (!isAssignable) {
+        val message = s"Failed to map value [$value] of type [$valueType] to paramName [${param.name.toString}] of" +
+          s" type [${param.typeSignature}] for method [$funcName]"
+        throw new IllegalArgumentException(message)
+      }
     }
   }
 

--- a/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/MockStepObject.scala
+++ b/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/MockStepObject.scala
@@ -19,6 +19,10 @@ object MockStepObject {
     string
   }
 
+  def mockStepFunctionWithOptionalGenericParams(list: Option[Seq[String]]): String ={
+    list.getOrElse(List("chicken")).headOption.getOrElse("chicken")
+  }
+
   def mockStringListStepFunction(listSize: Int): PipelineStepResponse = {
     PipelineStepResponse(Some(List.tabulate(listSize)(_.toString)), None)
   }

--- a/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/MockStepObject.scala
+++ b/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/MockStepObject.scala
@@ -23,6 +23,10 @@ object MockStepObject {
     list.getOrElse(List("chicken")).headOption.getOrElse("chicken")
   }
 
+  def mockStepFunctionWithPrimitives(i: Int, l: Long, d: Double, f: Float, c: Char, by: Option[Byte], s: Short): Int ={
+    i
+  }
+
   def mockStringListStepFunction(listSize: Int): PipelineStepResponse = {
     PipelineStepResponse(Some(List.tabulate(listSize)(_.toString)), None)
   }

--- a/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/utils/ReflectionUtilsTests.scala
+++ b/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/utils/ReflectionUtilsTests.scala
@@ -61,6 +61,17 @@ class ReflectionUtilsTests extends FunSpec {
       assert(thrown.getMessage == "typo is not a valid function!")
     }
 
+    it("Should return an informative error if the parameter types do not match function params"){
+      val step = PipelineStep(None, None, None, None, None,
+        Some(EngineMeta(Some("MockStepObject.mockStepFunctionWithOptionalGenericParams"))))
+      val thrown = intercept[IllegalArgumentException] {
+        ReflectionUtils.processStep(step, Map[String, Any]("list" -> 1), pipelineContext)
+      }
+      val message = "Failed to map value [Some(1)] of type [Some(Integer)] to paramName [list] of" +
+        " type [Option[Seq[String]]] for method [mockStepFunctionWithOptionalGenericParams]"
+      assert(thrown.getMessage == message)
+    }
+
   }
 
   describe("ReflectionUtils - loadClass") {

--- a/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/utils/ReflectionUtilsTests.scala
+++ b/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/utils/ReflectionUtilsTests.scala
@@ -6,11 +6,12 @@ import org.scalatest.FunSpec
 class ReflectionUtilsTests extends FunSpec {
   private val FIVE = 5
   describe("ReflectionUtil - processStep") {
+    val pipeline = Pipeline(Some("TestPipeline"))
     val pipelineContext = PipelineContext(None, None, None, PipelineSecurityManager(), PipelineParameters(),
       Some(List("com.acxiom.pipeline.steps", "com.acxiom.pipeline")), PipelineStepMapper(), None, None)
     it("Should process step function") {
       val step = PipelineStep(None, None, None, None, None, Some(EngineMeta(Some("MockStepObject.mockStepFunction"))))
-      val response = ReflectionUtils.processStep(step,
+      val response = ReflectionUtils.processStep(step, pipeline,
         Map[String, Any]("string" -> "string", "boolean" -> true), pipelineContext)
       assert(response.isInstanceOf[PipelineStepResponse])
       assert(response.asInstanceOf[PipelineStepResponse].primaryReturn.isDefined)
@@ -22,7 +23,7 @@ class ReflectionUtilsTests extends FunSpec {
     it("Should process step function with non-PipelineStepResponse") {
       val step = PipelineStep(None, None, None, None, None,
         Some(EngineMeta(Some("MockStepObject.mockStepFunctionAnyResponse"))))
-      val response = ReflectionUtils.processStep(step, Map[String, Any]("string" -> "string"), pipelineContext)
+      val response = ReflectionUtils.processStep(step, pipeline, Map[String, Any]("string" -> "string"), pipelineContext)
       assert(response.isInstanceOf[PipelineStepResponse])
       assert(response.asInstanceOf[PipelineStepResponse].primaryReturn.isDefined)
       assert(response.asInstanceOf[PipelineStepResponse].primaryReturn.getOrElse("") == "string")
@@ -31,7 +32,7 @@ class ReflectionUtilsTests extends FunSpec {
     it("Should process step with Option") {
       val step = PipelineStep(None, None, None, None, None,
         Some(EngineMeta(Some("MockStepObject.mockStepFunction"))))
-      val response = ReflectionUtils.processStep(step,
+      val response = ReflectionUtils.processStep(step, pipeline,
         Map[String, Any]("string" -> "string", "boolean" -> Some(true), "opt" -> "Option"), pipelineContext)
       assert(response.isInstanceOf[PipelineStepResponse])
       assert(response.asInstanceOf[PipelineStepResponse].primaryReturn.isDefined)
@@ -45,7 +46,7 @@ class ReflectionUtilsTests extends FunSpec {
     it("Should process step with default value") {
       val step = PipelineStep(None, None, None, None, None,
         Some(EngineMeta(Some("MockStepObject.mockStepFunctionWithDefaultValue"))))
-      val response = ReflectionUtils.processStep(step,
+      val response = ReflectionUtils.processStep(step, pipeline,
         Map[String, Any]("string" -> "string"), pipelineContext)
       assert(response.isInstanceOf[PipelineStepResponse])
       assert(response.asInstanceOf[PipelineStepResponse].primaryReturn.isDefined)
@@ -56,19 +57,19 @@ class ReflectionUtilsTests extends FunSpec {
       val step = PipelineStep(None, None, None, None, None,
         Some(EngineMeta(Some("MockStepObject.typo"))))
       val thrown = intercept[IllegalArgumentException]{
-        val response = ReflectionUtils.processStep(step, Map[String, Any](), pipelineContext)
+        val response = ReflectionUtils.processStep(step, pipeline, Map[String, Any](), pipelineContext)
       }
       assert(thrown.getMessage == "typo is not a valid function!")
     }
 
     it("Should return an informative error if the parameter types do not match function params"){
-      val step = PipelineStep(None, None, None, None, None,
+      val step = PipelineStep(Some("chicken"), None, None, None, None,
         Some(EngineMeta(Some("MockStepObject.mockStepFunctionWithOptionalGenericParams"))))
-      val thrown = intercept[IllegalArgumentException] {
-        ReflectionUtils.processStep(step, Map[String, Any]("list" -> 1), pipelineContext)
+      val thrown = intercept[PipelineException] {
+        ReflectionUtils.processStep(step, pipeline, Map[String, Any]("list" -> 1), pipelineContext)
       }
       val message = "Failed to map value [Some(1)] of type [Some(Integer)] to paramName [list] of" +
-        " type [Option[Seq[String]]] for method [mockStepFunctionWithOptionalGenericParams]"
+        " type [Option[Seq[String]]] for method [mockStepFunctionWithOptionalGenericParams] in step [chicken] in pipeline [TestPipeline]"
       assert(thrown.getMessage == message)
     }
 
@@ -83,7 +84,7 @@ class ReflectionUtilsTests extends FunSpec {
         "c" -> '1',
         "by" -> 1.toByte.asInstanceOf[java.lang.Byte]
       )
-      val response = ReflectionUtils.processStep(step, map, pipelineContext)
+      val response = ReflectionUtils.processStep(step, pipeline, map, pipelineContext)
       assert(response.isInstanceOf[PipelineStepResponse])
       assert(response.asInstanceOf[PipelineStepResponse].primaryReturn.isDefined)
       assert(response.asInstanceOf[PipelineStepResponse].primaryReturn.get == 1)

--- a/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/utils/ReflectionUtilsTests.scala
+++ b/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/utils/ReflectionUtilsTests.scala
@@ -72,6 +72,22 @@ class ReflectionUtilsTests extends FunSpec {
       assert(thrown.getMessage == message)
     }
 
+    it("should handle primitive types"){
+      val step = PipelineStep(None, None, None, None, None,
+        Some(EngineMeta(Some("MockStepObject.mockStepFunctionWithPrimitives"))))
+      val map = Map[String, Any]("i" -> 1,
+        "l" -> 1L,
+        "s" -> 1.toShort.asInstanceOf[java.lang.Short],
+        "d" -> 1.0D,
+        "f" -> 1.0F,
+        "c" -> '1',
+        "by" -> 1.toByte.asInstanceOf[java.lang.Byte]
+      )
+      val response = ReflectionUtils.processStep(step, map, pipelineContext)
+      assert(response.isInstanceOf[PipelineStepResponse])
+      assert(response.asInstanceOf[PipelineStepResponse].primaryReturn.isDefined)
+      assert(response.asInstanceOf[PipelineStepResponse].primaryReturn.get == 1)
+    }
   }
 
   describe("ReflectionUtils - loadClass") {

--- a/streaming-pipeline-drivers/pom.xml
+++ b/streaming-pipeline-drivers/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.acxiom</groupId>
         <artifactId>spark-pipeline-driver</artifactId>
-        <version>1.3.3-SNAPSHOT</version>
+        <version>1.3.4-SNAPSHOT</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
Added a validation method to ReflectionUtils called validateParamTypeAssignment that is called from mapMethodParameters which checks the type of each parameter and value before assignment and throws an exceptions if the param type is not assignable from the value type.