### PR TITLE
Fix issue with validateParamTypeAssignment on 'Any' typed param

### DIFF
--- a/common-pipeline-steps/src/main/scala/com/acxiom/pipeline/steps/HDFSSteps.scala
+++ b/common-pipeline-steps/src/main/scala/com/acxiom/pipeline/steps/HDFSSteps.scala
@@ -54,7 +54,7 @@ object HDFSSteps {
   )
   def createFileManager(pipelineContext: PipelineContext): Option[HDFSFileManager] = {
     if (pipelineContext.sparkSession.isDefined) {
-      Some(HDFSFileManager(pipelineContext.sparkSession.get))
+      Some(HDFSFileManager(pipelineContext.sparkSession.get.sparkContext.getConf))
     } else {
       None
     }

--- a/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/fs/HDFSFileManager.scala
+++ b/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/fs/HDFSFileManager.scala
@@ -3,15 +3,16 @@ package com.acxiom.pipeline.fs
 import java.io.{FileNotFoundException, InputStream, OutputStream}
 
 import org.apache.hadoop.fs.{FileSystem, LocatedFileStatus, Path, RemoteIterator}
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.SparkConf
+import org.apache.spark.deploy.SparkHadoopUtil
 
 import scala.annotation.tailrec
 
 /**
   * HDFS based implementation of the FileManager.
   */
-case class HDFSFileManager(sparkSession: SparkSession) extends FileManager {
-  private val configuration = sparkSession.sparkContext.hadoopConfiguration
+case class HDFSFileManager(conf: SparkConf) extends FileManager {
+  private val configuration = SparkHadoopUtil.get.newConfiguration(conf)
   private val fileSystem = FileSystem.get(configuration)
 
   override def exists(path: String): Boolean = fileSystem.exists(new Path(path))

--- a/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/utils/DriverUtils.scala
+++ b/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/utils/DriverUtils.scala
@@ -8,7 +8,7 @@ import org.apache.hadoop.io.LongWritable
 import org.apache.http.client.entity.UrlEncodedFormEntity
 import org.apache.log4j.Logger
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.DataFrame
 import org.json4s.native.JsonMethods.parse
 import org.json4s.reflect.Reflector
 import org.json4s.{DefaultFormats, Extraction, Formats}
@@ -152,11 +152,8 @@ object DriverUtils {
     } else {
       tempConf
     }
-    val sparkSession = SparkSession.builder().config(sparkConf).getOrCreate()
-    val fileManager = ReflectionUtils.loadClass(fileLoaderClassName,
-      Some(Map("sparkSession" -> sparkSession))).asInstanceOf[FileManager]
+    val fileManager = ReflectionUtils.loadClass(fileLoaderClassName, Some(Map("conf" -> sparkConf))).asInstanceOf[FileManager]
     val json = Source.fromInputStream(fileManager.getInputStream(path)).mkString
-    sparkSession.stop()
     json
   }
 }

--- a/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/utils/ReflectionUtils.scala
+++ b/spark-pipeline-engine/src/main/scala/com/acxiom/pipeline/utils/ReflectionUtils.scala
@@ -234,9 +234,10 @@ object ReflectionUtils {
                                           funcName: String,
                                           stepId: Option[String],
                                           pipelineId: Option[String]): Unit = {
-    if (!(isOption && value.asInstanceOf[Option[_]].isEmpty)) {
+    val paramType = if (isOption) param.typeSignature.typeArgs.head else param.typeSignature
+    if (!(isOption && value.asInstanceOf[Option[_]].isEmpty) && paramType.toString.toLowerCase != "any") {
       val finalValue = if (isOption) value.asInstanceOf[Option[_]].get else value
-      val paramClass = runtimeMirror.runtimeClass(if (isOption) param.typeSignature.typeArgs.head else param.typeSignature)
+      val paramClass = runtimeMirror.runtimeClass(paramType)
       val isAssignable = finalValue match {
         case b: java.lang.Boolean => paramClass.isAssignableFrom(b.asInstanceOf[Boolean].getClass)
         case i: java.lang.Integer => paramClass.isAssignableFrom(i.asInstanceOf[Int].getClass)

--- a/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/MockStepObject.scala
+++ b/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/MockStepObject.scala
@@ -23,7 +23,7 @@ object MockStepObject {
     list.getOrElse(List("chicken")).headOption.getOrElse("chicken")
   }
 
-  def mockStepFunctionWithPrimitives(i: Int, l: Long, d: Double, f: Float, c: Char, by: Option[Byte], s: Short): Int ={
+  def mockStepFunctionWithPrimitives(i: Int, l: Long, d: Double, f: Float, c: Char, by: Option[Byte], s: Short, a: Any): Int ={
     i
   }
 

--- a/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/fs/FileManagerTests.scala
+++ b/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/fs/FileManagerTests.scala
@@ -101,7 +101,7 @@ class FileManagerTests extends FunSpec with Suite {
         .setMaster("local")
         .set("spark.hadoop.fs.defaultFS", miniCluster.getFileSystem().getUri.toString)
       val sparkSession = SparkSession.builder().config(conf).getOrCreate()
-      val fileManager = HDFSFileManager(sparkSession)
+      val fileManager = HDFSFileManager(conf)
       // These methods do nothing, so call them and then run file operations
       fileManager.connect()
       fileManager.disconnect()

--- a/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/utils/ReflectionUtilsTests.scala
+++ b/spark-pipeline-engine/src/test/scala/com/acxiom/pipeline/utils/ReflectionUtilsTests.scala
@@ -82,7 +82,8 @@ class ReflectionUtilsTests extends FunSpec {
         "d" -> 1.0D,
         "f" -> 1.0F,
         "c" -> '1',
-        "by" -> 1.toByte.asInstanceOf[java.lang.Byte]
+        "by" -> 1.toByte.asInstanceOf[java.lang.Byte],
+        "a" -> "anyValue"
       )
       val response = ReflectionUtils.processStep(step, pipeline, map, pipelineContext)
       assert(response.isInstanceOf[PipelineStepResponse])


### PR DESCRIPTION
Currently the validateParamTypeAssignment method in ReflectionUtils will through an exception if the method it is checking against has an 'Any' type for one of it's parameters (ScalaSteps.processScriptWithValue for example). I've added a check for the Any type to prevent trying to get the runtime class of it.